### PR TITLE
WIP Bug#974692 Selectively resolve mini manifest urls

### DIFF
--- a/lib/apk_hash.js
+++ b/lib/apk_hash.js
@@ -36,7 +36,7 @@ withConfig(function(config) {
     var dirname;
 
     if (/^\w+:\/\//.test(manifestUrl)) {
-      dirname = url.resolve(manifestUrl, '.');
+      dirname = manifestUrl;
     } else {
       dirname = path.dirname(path.resolve(process.cwd(), manifestUrl));
     }

--- a/lib/cli_dev_build.js
+++ b/lib/cli_dev_build.js
@@ -3,7 +3,6 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 var path = require('path');
-var url = require('url');
 
 var androidifier = require('./manifest_androidifier');
 var generator = require('./generator_client');
@@ -18,7 +17,7 @@ module.exports = function(appData, config, cb) {
   var loaderDirname;
   var manifestUrl = appData.manifestUrl;
   if (/^\w+:\/\//.test(manifestUrl)) {
-    loaderDirname = url.resolve(manifestUrl, ".");
+    loaderDirname = manifestUrl;
   } else {
     loaderDirname = path.resolve(process.cwd(), manifestUrl);
   }

--- a/lib/front_controller.js
+++ b/lib/front_controller.js
@@ -3,7 +3,6 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 var path = require('path');
-var url = require('url');
 
 var fs = require('fs.extra');
 
@@ -56,7 +55,7 @@ function cacheMissGenerateAPK(manifestUrl, appType, config, log, cacheApkFn, cb,
   var loaderDirname;
 
   if (/^\w+:\/\//.test(manifestUrl)) {
-    loaderDirname = url.resolve(manifestUrl, ".");
+    loaderDirname = manifestUrl;
   } else {
     loaderDirname = path.loaderDirname(path.resolve(process.cwd(), manifestUrl));
   }


### PR DESCRIPTION
This part of the original prototype seemed dodgy.

Some places, we need a canonical url and others it sounds like we need to maintain it's original form.

Getting this wrong could defeat caching layers.

A cursory check, this seems correct. Maybe we can see if this seems to fix Bug#974692
