### PR TITLE
possible fix for Bug#1060473

### DIFF
--- a/lib/file_loader.js
+++ b/lib/file_loader.js
@@ -12,7 +12,7 @@ var request = require('request');
 var fsUtil = require('./fs_util');
 
 // Bug#1017184 - MS IIS/7.0 requires a UA
-var opts = { headers: {}};
+var opts = { headers: {}, timeout: 30000 };
 opts.headers['User-Agent'] = 'APKFactory/1.0';
 
 /**
@@ -77,8 +77,12 @@ HttpFileLoader.prototype = _.extend(new FileLoader(), {
   copy: function(suffix, destFile, cb) {
     var srcFile = url.resolve(this.prefix, suffix);
     fsUtil.ensureDirectoryExistsFor(destFile);
-    var r = request(srcFile, opts).pipe(fs.createWriteStream(destFile));
-    r.on('finish', cb);
+    request(srcFile, opts, function (error, response, body) {
+      if (error || response.statusCode !== 200) {
+        return cb(error || new Error('Unexpected status code: ' + response.statusCode + ' copying ' + srcFile));
+      }
+      fs.writeFile(destFile, body, cb);
+    });
   }
 
 });


### PR DESCRIPTION
Under still unknown conditions HttpFileLoader.copy fails to call
the callback while loading icons for the apk_project_builder. This
causes the build to hang and never decrement the activeBuilds counter
which eventually exhausts the concurrent build limit.

This change buffers the icon instead of streaming to make the error
handling more explicit.
