### PR TITLE
Fixes #84 partially reverts #82

### DIFF
--- a/lib/file_loader.js
+++ b/lib/file_loader.js
@@ -77,17 +77,17 @@ HttpFileLoader.prototype = _.extend(new FileLoader(), {
   copy: function(suffix, destFile, cb) {
     var srcFile = url.resolve(this.prefix, suffix);
     fsUtil.ensureDirectoryExistsFor(destFile);
-    var r = request(srcFile, opts).on('error', function(error){ return cb(error);}).pipe(fs.createWriteStream(destFile));
-    r.on('response',function(response){
-      if (200 !== response.statusCode){
-        return cb(new Error('Unexpected status code: ' + response.statusCode + ' copying ' + srcFile));
-      }
-    });
-    r.on('error', function(error){
-      return cb(error);
-    });
-    r.on('finish', cb);
-  }
+    request(srcFile, opts)
+      .on('error', function(error){ 
+        return cb(error);
+      })
+      .on('response',function(response){
+        if (200 !== response.statusCode){
+          return cb(new Error('Unexpected status code: ' + response.statusCode + ' copying ' + srcFile));
+        }
+      })
+      .pipe(fs.createWriteStream(destFile))
+      .on('finish', cb);
 
 });
 

--- a/lib/file_loader.js
+++ b/lib/file_loader.js
@@ -88,7 +88,7 @@ HttpFileLoader.prototype = _.extend(new FileLoader(), {
       })
       .pipe(fs.createWriteStream(destFile))
       .on('finish', cb);
-
+  }
 });
 
 

--- a/lib/file_loader.js
+++ b/lib/file_loader.js
@@ -77,12 +77,16 @@ HttpFileLoader.prototype = _.extend(new FileLoader(), {
   copy: function(suffix, destFile, cb) {
     var srcFile = url.resolve(this.prefix, suffix);
     fsUtil.ensureDirectoryExistsFor(destFile);
-    request(srcFile, opts, function (error, response, body) {
-      if (error || response.statusCode !== 200) {
-        return cb(error || new Error('Unexpected status code: ' + response.statusCode + ' copying ' + srcFile));
+    var r = request(srcFile, opts).on('error', function(error){ return cb(error);}).pipe(fs.createWriteStream(destFile));
+    r.on('response',function(response){
+      if (200 !== response.statusCode){
+        return cb(new Error('Unexpected status code: ' + response.statusCode + ' copying ' + srcFile));
       }
-      fs.writeFile(destFile, body, cb);
     });
+    r.on('error', function(error){
+      return cb(error);
+    });
+    r.on('finish', cb);
   }
 
 });


### PR DESCRIPTION
When requests are not streamed, the icon images are corrupted.
This was introduced in #82 . I have tried to maintain the pipe while still listening to the response or errors. 

Possibly fixes #84 . Not sure if there're bugs though. :baby: 