### PR TITLE
FileLoader.copy should use a buffer instead of string

### DIFF
--- a/lib/file_loader.js
+++ b/lib/file_loader.js
@@ -12,7 +12,7 @@ var request = require('request');
 var fsUtil = require('./fs_util');
 
 // Bug#1017184 - MS IIS/7.0 requires a UA
-var opts = { headers: {}, timeout: 30000 };
+var opts = { headers: {}, timeout: 30000, encoding: null };
 opts.headers['User-Agent'] = 'APKFactory/1.0';
 
 /**


### PR DESCRIPTION
This was an oversight of #82. 

I assumed incorrectly that an unset encoding in `request` would use a buffer but it must be explicitly set to `null`.

@kumar303 r?

cc @asdofindia @kyoshino